### PR TITLE
[Feat] #25 회원 비밀번호 재설정

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -125,6 +125,26 @@ const emailAuthForPwReset = async (req, res) => {
   }
 };
 
+const resetPassword = async (req, res) => {
+  const { email, password, confirmPassword } = req.body;
+
+  if (password !== confirmPassword) {
+    return res.status(CODE.BAD_REQUEST).json(form.fail(MSG.CONFIRM_PW_MISMATCH));
+  }
+
+  try {
+    const isExistUser = await userService.findUserByEmail(email);
+    if (!isExistUser) return res.status(CODE.NOT_FOUND).json(form.fail(MSG.EMAIL_NOT_EXIST));
+
+    await userService.resetPassword(isExistUser.userIdx, password);
+
+    return res.status(CODE.OK).json(form.success());
+  } catch (err) {
+    console.log('Ctrl Error: resetPassword ', err);
+    return res.status(CODE.INTERNAL_SERVER_ERROR).json(form.fail(MSG.INTERNAL_SERVER_ERROR));
+  }
+};
+
 module.exports = {
   join,
   login,
@@ -132,4 +152,5 @@ module.exports = {
   emailAuthForJoin,
   sendEmailForPwReset,
   emailAuthForPwReset,
+  resetPassword,
 };

--- a/dao/user.js
+++ b/dao/user.js
@@ -116,6 +116,26 @@ const setIsEmailAuth = async idx => {
   }
 };
 
+const resetPassword = async (idx, password) => {
+  let connection;
+  try {
+    connection = await pool.getConnection(async conn => conn);
+
+    const sql = `UPDATE user
+                    SET password = '${password}'
+                  WHERE user_idx = '${idx}'`;
+
+    const [row] = await connection.query(sql);
+
+    return !!Object.keys(row);
+  } catch (err) {
+    console.log(`===DB Error > ${err}===`);
+    throw new Error(err);
+  } finally {
+    connection.release();
+  }
+};
+
 module.exports = {
   join,
   findUserByEmail,
@@ -123,4 +143,5 @@ module.exports = {
   setEmailAuthNum,
   getEmailAuthNum,
   setIsEmailAuth,
+  resetPassword
 };

--- a/middleware/validator/user.js
+++ b/middleware/validator/user.js
@@ -80,10 +80,31 @@ const checkEmail = [
     .withMessage('이메일은 최소 10글자부터 최대 50글자까지 가능합니다.'),
 ];
 
+const resetPassword = [
+  body('email')
+    .notEmpty()
+    .withMessage('이메일을 입력해주세요.')
+    .isEmail()
+    .withMessage('이메일은 이메일 형식이어야 합니다.')
+    .isLength({ min: 10, max: 50 })
+    .withMessage('이메일은 최소 10글자부터 최대 50글자까지 가능합니다.'),
+  body('password')
+    .notEmpty()
+    .withMessage('비밀번호를 입력해주세요.')
+    .isLength({ min: 5, max: 20 })
+    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+  body('confirmPassword')
+    .notEmpty()
+    .withMessage('확인 비밀번호를 입력해주세요.')
+    .isLength({ min: 5, max: 20 })
+    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+];
+
 module.exports = {
   join,
   login,
   emailAuthForJoin,
   emailAuthForPwReset,
   checkEmail,
+  resetPassword
 };

--- a/routes/user.js
+++ b/routes/user.js
@@ -12,5 +12,7 @@ router.get('/logout', auth.checkToken, userCtrl.logout);
 router.patch('/email-auth/join', Validator.emailAuthForJoin, ValidatorError.err, userCtrl.emailAuthForJoin);
 router.post('/email-auth/password', Validator.checkEmail, ValidatorError.err, userCtrl.sendEmailForPwReset);
 router.get('/email-auth/password', Validator.emailAuthForPwReset, ValidatorError.err, userCtrl.emailAuthForPwReset);
+router.get('/email-auth/password', Validator.emailAuthForPwReset, ValidatorError.err, userCtrl.emailAuthForPwReset);
+router.patch('/password/reset', Validator.resetPassword, ValidatorError.err, userCtrl.resetPassword);
 
 module.exports = router;

--- a/service/user.js
+++ b/service/user.js
@@ -137,6 +137,17 @@ const emailAuthForPwReset = async (userIdx, reqNum) => {
   }
 };
 
+const resetPassword = async (userIdx, password) => {
+  try {
+    const hashPassword = await encrypt.hash(password);
+    await userDao.resetPassword(userIdx, hashPassword);
+    return CODE.OK;
+  } catch (err) {
+    console.log('Service Error: emailAuthForPwReset ', err);
+    throw new Error(err);
+  }
+};
+
 module.exports = {
   sendEmail,
   join,
@@ -146,4 +157,5 @@ module.exports = {
   emailAuthForJoin,
   sendEmailForPwReset,
   emailAuthForPwReset,
+  resetPassword
 };


### PR DESCRIPTION
## what is this PR?
- 회원 비밀번호 재설정 api 생성
- PATCH /api/users/password/reset
   - reset을 추가하고 싶지 않은데, 비밀번호 재설정(비밀번호 찾기 시:비로그인)과 비밀번호 변경(로그인이 되있는 상태) 을 구분하기 위해 사용🤔
   - body : email, password, confirmPassword
- 없는 email 일 경우 실패
- 비밀번호와 비밀번호 확인이 일치하지 않을 경우 실패

## API Docs
![image](https://user-images.githubusercontent.com/57309520/154348106-20545282-d1fc-4d15-9ea3-adc91ced4af8.png)

close #25 