### PR TITLE
[Feat] #27 회원 비밀번호 변경

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -161,6 +161,9 @@ const changePassword = async (req, res) => {
     const isCorrectPassword = await encrypt.compare(curPassword, user.password);
     if (!isCorrectPassword) return res.status(CODE.BAD_REQUEST).json(form.fail(MSG.PW_MISMATCH));
 
+    const isSamePassword = await encrypt.compare(newPassword, user.password);
+    if (isSamePassword) return res.status(CODE.BAD_REQUEST).json(form.fail("기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."));
+
     await userService.resetPassword(userIdx, newPassword);
 
     return res.status(CODE.OK).json(form.success());

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -125,6 +125,26 @@ const emailAuthForPwReset = async (req, res) => {
   }
 };
 
+const resetPassword = async (req, res) => {
+  const { email, password, confirmPassword } = req.body;
+
+  if (password !== confirmPassword) {
+    return res.status(CODE.BAD_REQUEST).json(form.fail(MSG.CONFIRM_PW_MISMATCH));
+  }
+
+  try {
+    const isExistUser = await userService.findUserByEmail(email);
+    if (!isExistUser) return res.status(CODE.NOT_FOUND).json(form.fail(MSG.EMAIL_NOT_EXIST));
+
+    await userService.resetPassword(isExistUser.userIdx, password);
+
+    return res.status(CODE.OK).json(form.success());
+  } catch (err) {
+    console.log('Ctrl Error: resetPassword ', err);
+    return res.status(CODE.INTERNAL_SERVER_ERROR).json(form.fail(MSG.INTERNAL_SERVER_ERROR));
+  }
+};
+
 module.exports = {
   join,
   login,
@@ -132,4 +152,5 @@ module.exports = {
   emailAuthForJoin,
   sendEmailForPwReset,
   emailAuthForPwReset,
+  resetPassword,
 };

--- a/dao/user.js
+++ b/dao/user.js
@@ -116,6 +116,26 @@ const setIsEmailAuth = async idx => {
   }
 };
 
+const resetPassword = async (idx, password) => {
+  let connection;
+  try {
+    connection = await pool.getConnection(async conn => conn);
+
+    const sql = `UPDATE user
+                    SET password = '${password}'
+                  WHERE user_idx = '${idx}'`;
+
+    const [row] = await connection.query(sql);
+
+    return !!Object.keys(row);
+  } catch (err) {
+    console.log(`===DB Error > ${err}===`);
+    throw new Error(err);
+  } finally {
+    connection.release();
+  }
+};
+
 module.exports = {
   join,
   findUserByEmail,
@@ -123,4 +143,5 @@ module.exports = {
   setEmailAuthNum,
   getEmailAuthNum,
   setIsEmailAuth,
+  resetPassword
 };

--- a/middleware/validator/user.js
+++ b/middleware/validator/user.js
@@ -100,11 +100,30 @@ const resetPassword = [
     .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
 ];
 
+const changePassword = [
+  body('curPassword')
+    .notEmpty()
+    .withMessage('비밀번호를 입력해주세요.')
+    .isLength({ min: 5, max: 20 })
+    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+  body('newPassword')
+    .notEmpty()
+    .withMessage('비밀번호를 입력해주세요.')
+    .isLength({ min: 5, max: 20 })
+    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+  body('confirmPassword')
+    .notEmpty()
+    .withMessage('확인 비밀번호를 입력해주세요.')
+    .isLength({ min: 5, max: 20 })
+    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+];
+
 module.exports = {
   join,
   login,
   emailAuthForJoin,
   emailAuthForPwReset,
   checkEmail,
-  resetPassword
+  resetPassword,
+  changePassword
 };

--- a/middleware/validator/user.js
+++ b/middleware/validator/user.js
@@ -80,10 +80,31 @@ const checkEmail = [
     .withMessage('이메일은 최소 10글자부터 최대 50글자까지 가능합니다.'),
 ];
 
+const resetPassword = [
+  body('email')
+    .notEmpty()
+    .withMessage('이메일을 입력해주세요.')
+    .isEmail()
+    .withMessage('이메일은 이메일 형식이어야 합니다.')
+    .isLength({ min: 10, max: 50 })
+    .withMessage('이메일은 최소 10글자부터 최대 50글자까지 가능합니다.'),
+  body('password')
+    .notEmpty()
+    .withMessage('비밀번호를 입력해주세요.')
+    .isLength({ min: 5, max: 20 })
+    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+  body('confirmPassword')
+    .notEmpty()
+    .withMessage('확인 비밀번호를 입력해주세요.')
+    .isLength({ min: 5, max: 20 })
+    .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+];
+
 module.exports = {
   join,
   login,
   emailAuthForJoin,
   emailAuthForPwReset,
   checkEmail,
+  resetPassword
 };

--- a/routes/user.js
+++ b/routes/user.js
@@ -14,5 +14,6 @@ router.post('/email-auth/password', Validator.checkEmail, ValidatorError.err, us
 router.get('/email-auth/password', Validator.emailAuthForPwReset, ValidatorError.err, userCtrl.emailAuthForPwReset);
 router.get('/email-auth/password', Validator.emailAuthForPwReset, ValidatorError.err, userCtrl.emailAuthForPwReset);
 router.patch('/password/reset', Validator.resetPassword, ValidatorError.err, userCtrl.resetPassword);
+router.patch('/password', auth.checkToken, Validator.changePassword, ValidatorError.err, userCtrl.changePassword);
 
 module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -12,5 +12,7 @@ router.get('/logout', auth.checkToken, userCtrl.logout);
 router.patch('/email-auth/join', Validator.emailAuthForJoin, ValidatorError.err, userCtrl.emailAuthForJoin);
 router.post('/email-auth/password', Validator.checkEmail, ValidatorError.err, userCtrl.sendEmailForPwReset);
 router.get('/email-auth/password', Validator.emailAuthForPwReset, ValidatorError.err, userCtrl.emailAuthForPwReset);
+router.get('/email-auth/password', Validator.emailAuthForPwReset, ValidatorError.err, userCtrl.emailAuthForPwReset);
+router.patch('/password/reset', Validator.resetPassword, ValidatorError.err, userCtrl.resetPassword);
 
 module.exports = router;

--- a/service/user.js
+++ b/service/user.js
@@ -137,6 +137,17 @@ const emailAuthForPwReset = async (userIdx, reqNum) => {
   }
 };
 
+const resetPassword = async (userIdx, password) => {
+  try {
+    const hashPassword = await encrypt.hash(password);
+    await userDao.resetPassword(userIdx, hashPassword);
+    return CODE.OK;
+  } catch (err) {
+    console.log('Service Error: emailAuthForPwReset ', err);
+    throw new Error(err);
+  }
+};
+
 module.exports = {
   sendEmail,
   join,
@@ -146,4 +157,5 @@ module.exports = {
   emailAuthForJoin,
   sendEmailForPwReset,
   emailAuthForPwReset,
+  resetPassword
 };

--- a/utils/responseMessage.js
+++ b/utils/responseMessage.js
@@ -32,6 +32,7 @@ const responseMessage = {
   EMAIL_NOT_EXIST: '존재하지 않는 유저 email 입니다.',
   NAME_ALREADY_EXIST: '존재하는 username 입니다.',
   ID_NOT_EXIST: '존재하지 않는 id 입니다.',
+  USER_NOT_EXIST: '존재하지 않는 회원입니다',
 
   PW_MISMATCH: '비밀번호가 일치하지 않습니다',
   CONFIRM_PW_MISMATCH: '비밀번호 확인이 일치하지 않습니다.',


### PR DESCRIPTION
## what is this PR?
- 회원 비밀번호 변경 api 생성
- PATCH /api/users/password
  - body: curPassword, newPassword, confirmPassword
- 기존 비밀번호와  curPassword 가 일치하지 않을 시 실패
- newPassword와 confirmPassword가 일치하지 않을 시 실패

## 고민
- 기존 비밀번호와 새로운 비밀번호가 동일하면 막아야할까요...?🤔🤔
- 동일하면 실패하도록 반영 완료

## 참고사항
- #25 커밋내역의 service와 dao 가 필요하여 부득이하게 커밋이 누적됐습니다. #27 커밋만 참고 부탁드려요!🏋️‍♂️
- 비밀번호 변경과 재설정의 차이가 무엇인지 궁금하다면?? #27 이슈 참고 부탁드립니다!

## API Docs
![image](https://user-images.githubusercontent.com/57309520/154358303-e01b9e83-1b1b-45c5-b698-d53916b73f4c.png)

close #27  