### PR TITLE
[Feat] #29 회원 비밀번호 확인 

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -125,6 +125,20 @@ const emailAuthForPwReset = async (req, res) => {
   }
 };
 
+const isCorrectPassword = async (req, res) => {
+  const userIdx = req.cookies.idx;
+  const { password } = req.query;
+
+  try {
+    const isCorrectPassword = await userService.isCorrectPassword(userIdx, password);
+    if (!isCorrectPassword) return res.status(CODE.BAD_REQUEST).json(form.fail(MSG.PW_MISMATCH));
+    return res.status(CODE.OK).json(form.success());
+  } catch (err) {
+    console.log('Ctrl Error: isCorrectPassword ', err);
+    return res.status(CODE.INTERNAL_SERVER_ERROR).json(form.fail(MSG.INTERNAL_SERVER_ERROR));
+  }
+};
+
 module.exports = {
   join,
   login,
@@ -132,4 +146,5 @@ module.exports = {
   emailAuthForJoin,
   sendEmailForPwReset,
   emailAuthForPwReset,
+  isCorrectPassword,
 };

--- a/middleware/validator/user.js
+++ b/middleware/validator/user.js
@@ -80,10 +80,19 @@ const checkEmail = [
     .withMessage('이메일은 최소 10글자부터 최대 50글자까지 가능합니다.'),
 ];
 
+const checkPassword = [
+  query('password')
+  .notEmpty()
+  .withMessage('비밀번호를 입력해주세요.')
+  .isLength({ min: 5, max: 20 })
+  .withMessage('비밀번호는 최소 5글자부터 최대 20글자까지 가능합니다.'),
+];
+
 module.exports = {
   join,
   login,
   emailAuthForJoin,
   emailAuthForPwReset,
   checkEmail,
+  checkPassword
 };

--- a/routes/user.js
+++ b/routes/user.js
@@ -12,5 +12,6 @@ router.get('/logout', auth.checkToken, userCtrl.logout);
 router.patch('/email-auth/join', Validator.emailAuthForJoin, ValidatorError.err, userCtrl.emailAuthForJoin);
 router.post('/email-auth/password', Validator.checkEmail, ValidatorError.err, userCtrl.sendEmailForPwReset);
 router.get('/email-auth/password', Validator.emailAuthForPwReset, ValidatorError.err, userCtrl.emailAuthForPwReset);
+router.get('/password', auth.checkToken, Validator.checkPassword, ValidatorError.err, userCtrl.isCorrectPassword);
 
 module.exports = router;

--- a/service/user.js
+++ b/service/user.js
@@ -7,8 +7,8 @@ const redis = require('../modules/redis');
 
 const EMAIL_AUTH_TYPE = {
   JOIN: 1,
-  PASSWORD_RESET: 2
-}
+  PASSWORD_RESET: 2,
+};
 
 const sendEmail = async (userIdx, email, type) => {
   try {
@@ -124,13 +124,24 @@ const sendEmailForPwReset = async (userIdx, email) => {
 
 const emailAuthForPwReset = async (userIdx, reqNum) => {
   try {
-    const type = 2;
+    const type = EMAIL_AUTH_TYPE.PASSWORD_RESET;
     const authNum = await userDao.getEmailAuthNum(userIdx, type);
 
     if (!authNum) return CODE.NOT_FOUND;
     if (authNum !== reqNum) return CODE.BAD_REQUEST;
 
     return CODE.OK;
+  } catch (err) {
+    console.log('Service Error: emailAuthForPwReset ', err);
+    throw new Error(err);
+  }
+};
+
+const isCorrectPassword = async (userIdx, password) => {
+  try {
+    const user = await findUserByIdx(userIdx);
+    const isCorrectPassword = await encrypt.compare(password, user.password);
+    return isCorrectPassword;
   } catch (err) {
     console.log('Service Error: emailAuthForPwReset ', err);
     throw new Error(err);
@@ -146,4 +157,5 @@ module.exports = {
   emailAuthForJoin,
   sendEmailForPwReset,
   emailAuthForPwReset,
+  isCorrectPassword,
 };


### PR DESCRIPTION
## what is this PR?
- 회원 비밀번호 확인 api 생성
- GET api/users/password
  - query : password

## API Docs
![image](https://user-images.githubusercontent.com/57309520/154362003-d2aecdf0-6550-4311-8e29-189ac5eb286e.png)
- 비밀번호 불일치 : 실패
- 비밀번호 일치 : 성공

## 고민
비밀번호 변경 에서나, 로그인시에도 비밀번호 일치 여부를 확인하는데, `userService.isCorrectPassword` 함수를 이용하여 회원 비밀번호의 일치 여부를 파악하도록 바꾸는게 좋을지 고민입니다.🤔
비밀번호 변경, 로그인시에는 `userService.isCorrectPassword` 함수 호출 전에 다른 비지니스 로직에서 암호화된 비밀번호를 가져올 수 있어서, `userService.isCorrectPassword` 함수 사용시 불필요하게 dao를 한번 더 호출하여 커넥션이 생깁니다...
하지만 `비밀번호 일치여부를 확인한다` 라는 맥락에서 같은 행동이어서, 같은 함수를 써주는게 더 통일성 있는 코드 같은데, 어떤 것이 좋을까요?😭😭

close #29 