### PR TITLE
[Fix]  #75 카카오 로그인 api 에서, 인가코드 javascript sdk 로 구해오도록 변경

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -5,12 +5,7 @@ const CODE = require('../utils/statusCode');
 const MSG = require('../utils/responseMessage');
 const form = require('../utils/responseForm');
 
-const getAuthCode = async (req, res) => {
-  const kakaoAuthURL = `${process.env.KAKAO_GET_AUTH_CODE_URL}client_id=${process.env.KAKAO_CLIENT_ID}&redirect_uri=${process.env.KAKAO_CALLBACK_URL}&response_type=code`;
-  res.redirect(kakaoAuthURL);
-};
-
-const getToken = async (req, res) => {
+const getKakaoToken = async (req, res) => {
   try {
     const token = await axios({
       method: 'post',
@@ -42,7 +37,7 @@ const getToken = async (req, res) => {
     .cookie('accessToken', authUser.token.accessToken, { httpOnly: true })
     .cookie('refreshToken', authUser.token.refreshToken, { httpOnly: true })
     .json(form.success(authUser.user));
-    
+
   } catch (err) {
     console.error(`=== Auth Ctrl getToken Error: ${err.data} === `);
     return res.status(CODE.INTERNAL_SERVER_ERROR).json(form.fail(MSG.INTERNAL_SERVER_ERROR));
@@ -50,6 +45,5 @@ const getToken = async (req, res) => {
 };
 
 module.exports = {
-  getAuthCode,
-  getToken,
+  getKakaoToken,
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -5,7 +5,6 @@ require('dotenv').config();
 
 const router = express.Router();
 
-router.get('/kakao', authCtrl.getAuthCode);
-router.get('/kakao/callback', authCtrl.getToken);
+router.get('/kakao/callback', authCtrl.getKakaoToken);
 
 module.exports = router;


### PR DESCRIPTION
## what is this PR?
- 카카오 로그인 api 에서, 인가코드 `javascript sdk` 로 구해오도록 변경
- 때문에 BE에서 `router.get('/kakao', authCtrl.getAuthCode);` 해당 라우터의 필요가 없어짐
- 인가코드 BE에서 FE로 변경 이유
  -  `REST api` 로 구할 시, 로그인 팝업창 open/close를 직접 제어해야함
  - `javascript sdk` 로 구할 시, 팝업창의  open/close가 자동으로 됨

## 카카오 api 동작 과정
- FE에서 인가코드를 가져와서 BE api 호출
- BE에서 해당 인가코드를 통해 자체 access/refesh 토큰 발급하여 FE에 전달
- FE에서 BE로부터 받은 데이터를 redux에 저장

close #75 