### PR TITLE
[Fix] #81 태그 스트레칭 조회시, mainBody 안들어가면 오류 발생 해결

### DIFF
--- a/controllers/stretching.js
+++ b/controllers/stretching.js
@@ -44,10 +44,10 @@ const getTagStretchings = async (req, res) => {
   try {
     const tag = {
       main: JSON.parse(req.query.main),
-      sub: JSON.parse(req.query.effect),
+      sub: JSON.parse(req.query.sub),
       tool: JSON.parse(req.query.tool),
-      posture: JSON.parse(req.query.posture),
       effect: JSON.parse(req.query.effect),
+      posture: JSON.parse(req.query.posture),
     };
 
     const { userIdx } = req.query;

--- a/dao/stretching.js
+++ b/dao/stretching.js
@@ -184,30 +184,30 @@ const getStretching = async (stretchingIdx, userIdx) => {
   }
 };
 
-const getTagStretchings = async ({ main, sub, tool, posture, effect }, userIdx) => {
+const getTagStretchings = async (tag, userIdx) => {
   let connection;
-
+  const firstSearch = Object.values(tag).findIndex(v => v);
   try {
     connection = await pool.getConnection(async conn => conn);
 
     const whereParam = {
-      main: main && `a.main_body REGEXP ${main}`,
-      sub: sub && `OR a.sub_body REGEXP ${sub}`,
-      tool: tool && `OR a.tool REGEXP ${tool}`,
+      main: tag.main && `a.main_body REGEXP ${tag.main}`,
+      sub: tag.sub && `${firstSearch < 1 ? 'OR' : ''} a.sub_body REGEXP ${tag.sub}`,
+      tool: tag.tool && `${firstSearch < 2 ? 'OR' : ''} a.tool REGEXP ${tag.tool}`,
       effect:
-        effect &&
-        `OR IFNULL((SELECT GROUP_CONCAT(effect_type SEPARATOR ' ')
+        tag.effect &&
+        `${firstSearch < 3 ? 'OR' : ''} IFNULL((SELECT GROUP_CONCAT(effect_type SEPARATOR ' ')
                                       FROM stretching_effect AS b
                                      WHERE a.stretching_idx = b.stretching_idx
                                   GROUP BY b.stretching_idx
-                                  ), '') REGEXP ${effect}`,
+                                  ), '') REGEXP ${tag.effect}`,
       posture:
-        posture &&
-        `OR IFNULL((SELECT GROUP_CONCAT(posture_type SEPARATOR ' ')
+        tag.posture &&
+        `${firstSearch < 4 ? 'OR' : ''} IFNULL((SELECT GROUP_CONCAT(posture_type SEPARATOR ' ')
                                         FROM stretching_posture AS c
                                        WHERE a.stretching_idx = c.stretching_idx
                                     GROUP BY c.stretching_idx
-                                   ) REGEXP ${posture}`,
+                                  ), '') REGEXP ${tag.posture}`,
     };
 
     const sql = `SELECT stretching_idx AS 'stretchingIdx'
@@ -243,7 +243,6 @@ const getTagStretchings = async ({ main, sub, tool, posture, effect }, userIdx) 
     connection.release();
   }
 };
-
 const getRecommendStretchings = async (stretchingIdx, userIdx) => {
   let connection;
 


### PR DESCRIPTION
## what is this PR?
- 태그 스트레칭 조회시, mainBody 안들어가면 오류 발생 해결
- 발생 원인
  - `dao` 에서 쿼리를 짤 때, `WHERE` 절에 `mainBody` 를 제외하고 나머지 태그에서 `OR`을 추가해주고 있음.
  - 따라서 첫번째가 `mainBody`가 아니었다면 `WHERE OR ~` 로 시작하여 쿼리 에러 발생
- 해결 방법
  - 첫번째 검색 인덱스를 찾아서 `firstSearch` 변수에 저장한 후, 해당 변수와 크기를 비교하여 `OR` 추가할지 말지 결정(엄청 맘에 들진 않음) 

close #81