### PR TITLE
[QA] #93 이메일 인증 메일 재전송 api 생성

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -66,6 +66,22 @@ const logout = async (req, res) => {
   }
 };
 
+const sendEmailForJoin = async (req, res) => {
+  try {
+    const { idx } = req.body;
+    const isExistUser = await userService.findUserByIdx(idx);
+    if (!isExistUser) return res.status(CODE.NOT_FOUND).json(form.fail(MSG.EMAIL_NOT_EXIST));
+
+    if (isExistUser.isEmailAuth) return res.status(CODE.BAD_REQUEST).json(form.fail("이미 이메일 인증된 사용자입니다."));
+
+    await userService.sendEmailForJoin(idx, isExistUser.email);
+    return res.status(CODE.OK).json(form.success());
+  } catch (err) {
+    console.error(`=== User Ctrl sendEmailForJoin Error: ${err} === `);
+    return res.status(CODE.INTERNAL_SERVER_ERROR).json(form.fail(MSG.INTERNAL_SERVER_ERROR));
+  }
+};
+
 const emailAuthForJoin = async (req, res) => {
   try {
     const emailAuthUser = req.body;
@@ -206,6 +222,7 @@ module.exports = {
   join,
   login,
   logout,
+  sendEmailForJoin,
   emailAuthForJoin,
   sendEmailForPwReset,
   emailAuthForPwReset,

--- a/middleware/validator/common.js
+++ b/middleware/validator/common.js
@@ -1,7 +1,9 @@
-const { param } = require('express-validator');
+const { param , body} = require('express-validator');
 
 const checkParamIdx = [param('idx', 'idx 는 숫자로만 이루어져야 합니다.').isInt().toInt()];
+const checkbodyIdx = [body('idx', 'idx 는 숫자로만 이루어져야 합니다.').isInt().toInt()];
 
 module.exports = {
   checkParamIdx,
+  checkbodyIdx,
 };

--- a/routes/user.js
+++ b/routes/user.js
@@ -3,12 +3,14 @@ const express = require('express');
 const router = express.Router();
 const userCtrl = require('../controllers/user');
 const Validator = require('../middleware/validator/user');
+const commonValidator = require('../middleware/validator/common');
 const ValidatorError = require('../middleware/validatorError');
 const auth = require('../middleware/auth');
 
 router.post('/join', Validator.join, ValidatorError.err, userCtrl.join);
 router.post('/login', Validator.login, ValidatorError.err, userCtrl.login);
 router.get('/logout', auth.checkToken, userCtrl.logout);
+router.post('/email-auth/join', commonValidator.checkbodyIdx, ValidatorError.err, userCtrl.sendEmailForJoin);
 router.patch('/email-auth/join', Validator.emailAuthForJoin, ValidatorError.err, userCtrl.emailAuthForJoin);
 router.post('/email-auth/password', Validator.checkEmail, ValidatorError.err, userCtrl.sendEmailForPwReset);
 router.get('/email-auth/password', Validator.emailAuthForPwReset, ValidatorError.err, userCtrl.emailAuthForPwReset);

--- a/service/user.js
+++ b/service/user.js
@@ -115,6 +115,15 @@ const findUserByIdx = async idx => {
   }
 };
 
+const sendEmailForJoin = async (userIdx, email) => {
+  try {
+    sendEmail(userIdx, email, EMAIL_AUTH_TYPE.JOIN);
+  } catch (err) {
+    console.error('User Service Error: sendEmailForJoin ', err);
+    throw new Error(err);
+  }
+};
+
 const emailAuthForJoin = async ({ userIdx, emailAuthNum: reqNum }) => {
   try {
     const user = await findUserByIdx(userIdx);
@@ -254,6 +263,7 @@ module.exports = {
   login,
   findUserByEmail,
   findUserByIdx,
+  sendEmailForJoin,
   emailAuthForJoin,
   sendEmailForPwReset,
   emailAuthForPwReset,


### PR DESCRIPTION
## Motivation 🤓
회원가입 후, 이메일 인증을 하지 않은 유저가 로그인시, 이전 메일을 찾기 어려울 때를 위해 `이메일 재전송 기능`을 추가하고자 함.
<br>

## Key Changes 🔑
- `post('/email-auth/password') api` 와 동일한 기능이기 때문에, `CTRL`와 `SERVICE`만 `emailAuthForJoin` 함수로 새로 만듦
- 요청시` body`에 `idx: userIdx` 값으로 받음
- 성공시 `success: true` 반환

![스크린샷 2022-04-27 오후 8 29 39](https://user-images.githubusercontent.com/57309520/165508735-e1a9ab0d-1e27-41c3-8474-b684d3d2614d.png)

<br>

## To Reviewers 🙋‍♀️
기존 기능과 유사하기 때문에 자체적으로 머지하겠습니다@!

close #93 