### PR TITLE
[QA]  #98 출석도장 전월달로 나오는 오류 해결

### DIFF
--- a/service/attendPoint.js
+++ b/service/attendPoint.js
@@ -24,7 +24,7 @@ const isDuplicateAttendPoint = async userIdx => {
 
 const getAttendPoints = async (userIdx, year, month) => {
   try {
-    const lastDateOfMonth = new Date(year, month - 1, 0).getDate();
+    const lastDateOfMonth = new Date(year, month, 0).getDate();
     const monthArray = new Array(lastDateOfMonth).fill(0);
 
     const attendPoints = await attendPointDao.getAttendPointsByYearMonth(userIdx, year, month);
@@ -32,7 +32,6 @@ const getAttendPoints = async (userIdx, year, month) => {
     attendPoints.forEach(attendPoint => {
       monthArray[+attendPoint.day - 1] = 1;
     });
-
     return monthArray;
   } catch (err) {
     console.error(`=== AttendPoint Service getAttendPoints Error: ${err} === `);


### PR DESCRIPTION
## Motivation 🤓
개월수가 이전달로 나오는 현상
ex) 3월 > 28일, 2월 > 31일
![스크린샷 2022-04-28 오후 11 11 29](https://user-images.githubusercontent.com/57309520/165771994-890a81af-ecf6-42dc-b531-b6c98f8814f5.png)
<br>

## Key Changes 🔑
- month 달의 마지막 날 구하기 :` new Date(연도, month, 0)`
- month가 0부터 시작하기 때문에 `-1`을 별도로 할 필요가 없었음.
<br>

close #98 