### PR TITLE
[QA] #115 탈퇴한 계정 email = null 로 변경하기

### DIFF
--- a/dao/user.js
+++ b/dao/user.js
@@ -257,6 +257,7 @@ const deleteUser = async idx => {
     const sql = `UPDATE user
                     SET delete_at = CURRENT_TIMESTAMP()
                       , kakao_id = null
+                      , email = null
                   WHERE user_idx = ${idx}`;
 
     const [row] = await connection.query(sql);


### PR DESCRIPTION
## Motivation 🤓
계정 탈퇴시, 이메일 정보를 그대로 갖고 있음 

동일한 계정으로 재가입시, 회원 활동 기록이 그대로 이어짐

계정 탈퇴시, `email = null` 로 변경하여, 동일한 계정 재가입시, `userIdx` 연결되어 회원 활동 기록이 이어지지 않도록 수정
<br>

## Key Changes 🔑
`UPDATE user
                    SET delete_at = CURRENT_TIMESTAMP()
                      , kakao_id = null
                      , email = null
                  WHERE user_idx = ${idx};`

### DB 스키마 변경
`user` > `email` : `NOT NULL, UNIQUE` 설정 해제
<br>

## To Reviewers 🙋‍♀️
<img width="1102" alt="스크린샷 2022-05-11 오후 11 25 34" src="https://user-images.githubusercontent.com/57309520/167873573-b93fac90-db90-4541-bdbc-1dd97d9bcfd8.png">

<img width="1086" alt="스크린샷 2022-05-11 오후 11 25 47" src="https://user-images.githubusercontent.com/57309520/167873609-b660a64a-7e52-47da-9281-b4ee0dd2e874.png">

close #115